### PR TITLE
Fix invalid component export name

### DIFF
--- a/transform/src/lib.rs
+++ b/transform/src/lib.rs
@@ -102,6 +102,7 @@ type GlobalMap<T> = HashMap<u32, HashMap<u32, T>>;
 enum GlobalExport {
     Existing {
         module_index: u32,
+        global_index: u32,
         export_name: String,
     },
     Synthesized {
@@ -120,8 +121,9 @@ impl GlobalExport {
         match self {
             Self::Existing {
                 module_index,
-                export_name,
-            } => format!("component-init-get-module{module_index}-global-{export_name}"),
+                global_index,
+                ..
+            } => format!("component-init-get-module{module_index}-global{global_index}"),
             Self::Synthesized {
                 module_index,
                 global_index,
@@ -178,6 +180,7 @@ impl Instrumentation {
             let export_name = export_name.as_ref().to_string();
             *name = GlobalExport::Existing {
                 module_index,
+                global_index,
                 export_name,
             };
         }


### PR DESCRIPTION
Currently some components fails with invalid export names

```
Error: export name component-init-get-module0-global-libc++.so:_ZTVNSt3__210moneypunctIwLb0EEE is not a valid extern name
expected : at ++.so:_ZTVNSt3__210moneypunctIwLb0EEE (at offset 0x19921ec)
```